### PR TITLE
login, account, signup page fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ temp.mkdir('uploads', function(err, dirPath)
 {
 	if (err)
 		throw err;
-	tempDir = dirPath;	
+	tempDir = dirPath;
 });
 
 var app = express();
@@ -158,7 +158,7 @@ app.use(function(req, res, next)
 {
 	if(req.url.indexOf('?_') > -1)
 		req.url = req.url.substring(0, req.url.indexOf('?_'));
-	
+
 	next();
 });
 
@@ -168,7 +168,7 @@ app.use(function(req, res, next)
 	next();
 });
 
-// old static flat files 
+// old static flat files
 app.use('/data', express.static(path.join(__dirname, 'browser', 'data'), { maxAge: week * 52 }));
 
 // stream files from fs/gridfs
@@ -372,7 +372,7 @@ app.post('/:username/presets', function(req, res, next) {
 })
 
 // -----
-// Graph routes 
+// Graph routes
 
 app.get(['/editor', '/edit'], graphController.edit.bind(graphController));
 
@@ -438,15 +438,15 @@ app.get('/:model/tag/:tag', requireController, function(req, res, next)
 	req.controller.findByTag(req, res, next);
 });
 
-// get 
+// get
 app.get('/:model/:id', requireController, function(req, res, next)
 {
 	req.controller.load(req, res, next);
 });
 
 // save
-app.post('/:model', 
-	requireController, 
+app.post('/:model',
+	requireController,
 	passportConf.isAuthenticated,
 	function(req, res, next)
 	{

--- a/browser/index.html
+++ b/browser/index.html
@@ -49,7 +49,7 @@
 							<iframe width="933" height="528" src="https://www.youtube.com/embed/9n9UdwaDe68" frameborder="0" allowfullscreen></iframe>
 						</p>
 
-						
+
 						<br><br>
 
 						<div class="clearfix"></div>
@@ -58,7 +58,7 @@
 				</div>
 			</div>
 		</div>
-	
+
 		<div class="clearfix"></div>
 
 		<footer class="footer"><div class="container"><div class="row"><div class="col-xs-12 col-sm-2"><a href="http://vizor.io"><img src="/images/logo--horizontal.png" width="147" height="40"></a></div><div class="col-xs-12 col-sm-8 text-center"><ul class="links footer-links">

--- a/browser/scripts/account-controller.js
+++ b/browser/scripts/account-controller.js
@@ -23,12 +23,14 @@ AccountController.prototype._bindEvents = function(el)
 	$('a.login', el).on('click', function(evt)
 	{
 		evt.preventDefault();
+		bootbox.hideAll();
 		that.openLoginModal();
 	});
 
 	$('a.signup', el).on('click', function(evt)
 	{
 		evt.preventDefault();
+		bootbox.hideAll();
 		that.openSignupModal();
 	});
 }
@@ -60,7 +62,7 @@ AccountController.prototype.openLoginModal = function()
 			error: function(err)
 			{
 				console.log(err);
-				bootbox.alert('Login failed!');
+				bootbox.alert("Sorry, your login failed. Please double check your e-mail and password.");
 			},
 			success: function(user)
 			{
@@ -85,6 +87,8 @@ AccountController.prototype.openSignupModal = function()
 		//onEscape: function() {  }
 	});
 
+	this._bindEvents(bb);
+
 	var formEl = $('#signup-form_id');
 	formEl.submit(function( event )
 	{
@@ -100,7 +104,7 @@ AccountController.prototype.openSignupModal = function()
 			error: function(err, msg)
 			{
 				console.log(err);
-				bootbox.alert('Signup failed: ' + err.responseJSON.msg);
+				bootbox.alert("Sorry, creating your account failed. Please make sure to fill in all the fields correctly.");
 			},
 			success: function(user)
 			{

--- a/browser/style/website.css
+++ b/browser/style/website.css
@@ -27,15 +27,158 @@
 .container {
 	font-family: 'dejavu' sans-serif !important;
     font-weight: normal;
-} 
+}
 
 h1 {
 	font-size: 50px;
 	font-family: 'dejavu' sans-serif !important;
     font-weight: normal;
-} 
+}
 
 iframe {
 	border: 0px;
+}
+
+/**
+ * Main layout
+ */
+
+#main-wrapper {
+  margin: 0 auto;
+}
+
+#content-wrapper {
+  clear: both;
+  margin: 0 auto;
+  padding: 80px 0 40px 0;
+}
+
+#content-wrapper .page-header {
+  margin-top: 0;
+}
+
+#content-wrapper .page-header h1 {
+  margin-top: 0;
+}
+
+#content-wrapper .alert {
+  margin-bottom: 24px;
+  font-weight: bold;
+  text-align: center;
+  font-size: 16px;
+}
+
+.alert-success,
+.alert-danger {
+  color: white;
+}
+
+.navbar {
+  margin-bottom: 0;
+  border: none;
+  min-width: 960px;
+}
+
+.navbar .container {
+  height: 50px;
+}
+
+#vizor-logo {
+  margin-top: 15px;
+}
+
+#info span {
+  font-size: 16px;
+}
+
+#info a,
+#info a:hover {
+  text-decoration: none;
+}
+
+#infopanelogo {
+  margin-left: 0;
+}
+
+#user-pulldown {
+  height: 50px;
+  display: block;
+  margin: 0;
+}
+
+#user-pulldown .dropdown {
+  height: 50px;
+  position: relative;
+}
+
+#user-pulldown .dropdown-toggle {
+  padding: 20px 24px 0 24px;
+  height: 50px;
+  font-weight: bold;
+}
+
+#user-pulldown .dropdown:hover .dropdown-menu {
+  display: block;
+  position: absolute;
+  top: 50px;
+  right: 0px;
+}
+
+#user-pulldown .dropdown:hover .dropdown-toggle {
+  background: #222;
+}
+
+#user-pulldown .dropdown .dropdown-menu li a {
+  padding: 12px;
+  border-bottom: 1px solid #222;
+}
+
+#user-pulldown .dropdown .dropdown-menu li.divider {
+  display: none;
+}
+
+#user-pulldown .dropdown-menu {
+  padding: 0;
+  border-bottom: none;
+  border-radius: 0px;
+}
+
+#user-pulldown a.login,
+#user-pulldown a.signup {
+  padding: 18px 12px;
+  display: inline-block;
+  height: 50px;
+}
+
+.page-header {
+  border-bottom: none;
+}
+
+.btn-danger {
+  color: #222;
+}
+
+.panel-heading {
+  padding: 12px;
+  background: #333;
+  border-bottom: 1px solid #222;
+}
+
+.panel-body {
+  padding-top: 12px;
+}
+
+#open-the-editor {
+  width: 150px;
+  text-align: center;
+  font-size: 12px;
+  height: 40px;
+  position: absolute;
+  left: 50%;
+  margin-left: -75px;
+  top: 5px;
+  padding: 12px 0 0 0;
+  color: white;
+  font-weight: bold;
 }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -6,6 +6,14 @@ var User = require('../models/user');
 var secrets = require('../config/secrets');
 var mailer = require('../lib/mailer');
 
+function parseErrors(errors) {
+  var parsedErrors = [];
+  for( var i=0; i < errors.length; i++ ) {
+    parsedErrors.push({ message: errors[i].msg });
+  }
+  return parsedErrors;
+}
+
 /**
  * GET /login
  * Login page.
@@ -34,7 +42,7 @@ var mailer = require('../lib/mailer');
  	var wantJson = req.xhr || req.path.slice(-5) === '.json'
 
  	if (errors) {
- 		req.flash('errors', errors);
+    req.flash('errors', parseErrors(errors));
  		return res.redirect('/login');
  	}
 
@@ -56,7 +64,7 @@ var mailer = require('../lib/mailer');
  			}
  			else
  			{
- 				res.redirect(req.session.returnTo || '/');
+ 				res.redirect(req.session.returnTo || '/account');
  			}
  		});
  	})(req, res, next);
@@ -67,7 +75,7 @@ var mailer = require('../lib/mailer');
  */
  exports.logout = function(req, res) {
  	req.logout();
- 	res.redirect('/');
+ 	res.redirect('/login');
  };
 
 /**
@@ -96,7 +104,7 @@ var mailer = require('../lib/mailer');
  	var errors = req.validationErrors();
 
  	if (errors) {
- 		req.flash('errors', errors);
+ 		req.flash('errors', parseErrors(errors));
  		return res.redirect('/signup');
  	}
 
@@ -134,7 +142,7 @@ var mailer = require('../lib/mailer');
  					}
  					else
  					{
- 						res.redirect(req.session.returnTo || '/');
+ 						res.redirect(req.session.returnTo || '/account');
  					}
  				});
  			});
@@ -182,13 +190,15 @@ var mailer = require('../lib/mailer');
  */
 
  exports.postUpdatePassword = function(req, res, next) {
+
  	req.assert('password', 'Password must be at least 4 characters long').len(4);
  	req.assert('confirmPassword', 'Passwords do not match').equals(req.body.password);
 
  	var errors = req.validationErrors();
 
  	if (errors) {
- 		req.flash('errors', errors);
+    req.flash('errors', parseErrors(errors));
+    console.log(parsedErrors);
  		return res.redirect('/account');
  	}
 
@@ -279,7 +289,7 @@ var mailer = require('../lib/mailer');
  	var errors = req.validationErrors();
 
  	if (errors) {
- 		req.flash('errors', errors);
+    req.flash('errors', parseErrors(errors));
  		return res.redirect('back');
  	}
 
@@ -335,7 +345,7 @@ var mailer = require('../lib/mailer');
 
  exports.getForgot = function(req, res) {
  	if (req.isAuthenticated()) {
- 		return res.redirect('/');
+ 		return res.redirect('/account');
  	}
  	res.render('account/forgot', {
  		title: 'Forgot Password'
@@ -354,7 +364,7 @@ var mailer = require('../lib/mailer');
  	var errors = req.validationErrors();
 
  	if (errors) {
- 		req.flash('errors', errors);
+    req.flash('errors', parseErrors(errors));
  		return res.redirect('/forgot');
  	}
 

--- a/views/account/forgot.handlebars
+++ b/views/account/forgot.handlebars
@@ -1,19 +1,22 @@
-<h1 class="form-header">Forgotten your password?</h1>
+<h1 class="form-header text-center"><i class="fa fa-key page-header-icon"></i>&nbsp;&nbsp;Forgot your password?</h1>
+
+<p style="text-align: center; padding: 12px 0 8px 0;">Enter your email address below and we will send you password reset instructions.</p>
 
 <!-- Form -->
-<form action="/forgot" id="forgot-form_id" class="panel" method="POST">
+<form action="/forgot" id="forgot-form_id" method="POST">
   <input type="hidden" name="_csrf" value={{_csrf}}>
 
-  <div class="form-group">
-    <p>Enter your email address below and we will send you password reset instructions.</p>
-    <input type="text" name="email" id="email_id" class="form-control input-lg" placeholder="E-mail" autofocus="true">
-  </div> <!-- / Email -->
+  <div class="panel-body">
+    <div class="form-group">
+      <input type="text" style="text-align: center; padding: 10px; height: auto;" name="email" id="email_id" class="form-control input-lg" placeholder="Your e-mail address" autofocus="true">
+    </div> <!-- / Email -->
 
-  <div class="form-actions">
-    <button class="btn btn-primary" type="submit">
-      <i class="fa fa-key"></i>
-      &nbsp;Reset Password
-    </button>
-  </div> <!-- / .form-actions -->
+    <div class="text-center" style="margin-top: 24px;">
+      <button class="btn btn-primary" type="submit">
+        <i class="fa fa-key"></i>
+        &nbsp;Reset Password
+      </button>
+    </div> <!-- / .form-actions -->
+  </div> <!-- / .panel-body -->
 </form>
 <!-- / Form -->

--- a/views/account/login.handlebars
+++ b/views/account/login.handlebars
@@ -1,27 +1,32 @@
-<h1 class="form-header">Please log in</h1>
+<h1 class="text-center form-header"><i class="fa fa-sign-in page-header-icon"></i>&nbsp;&nbsp;Login</h1>
+
+<p style="text-align: center; padding: 12px 0 8px 0;">Not registered? &nbsp;<a href="/signup" class="signup">Sign up</a> &nbsp;&nbsp;—&nbsp;&nbsp; <a href="/forgot" class="forgot">Forgot your password?</a></p>
 
 <!-- Form -->
-<form action="/login" id="login-form_id" class="panel" method="POST">
+<form action="/login" id="login-form_id" method="POST">
   <input type="hidden" name="_csrf" value={{_csrf}}>
 
-  <div class="form-group signin-password">
-    Not registered? <a href="/signup" class="signup">Sign up now!</a>
-  </div> <!-- / Password -->
+  <div class="panel-body">
 
-  <div class="form-group">
-    <input type="email" name="email" id="email_id" class="form-control input-lg" placeholder="E-mail" autofocus="true">
-  </div> <!-- / Email -->
+    <div class="row form-group">
+      <div class="col-sm-12 text-center">
+        <input type="email" name="email" style="text-align: center; padding: 10px; height: auto;" id="email_id" class="form-control input-lg" placeholder="Your e-mail address" autofocus="true">
+      </div>
+    </div> <!-- / Email -->
 
-  <div class="form-group signin-password">
-    <input type="password" name="password" id="password_id" class="form-control input-lg" placeholder="Password">
-    <a href="/forgot" class="forgot">Forgot password?</a>
-  </div> <!-- / Password -->
+    <div class="row form-group">
+      <div class="col-sm-12 text-center">
+        <input type="password" name="password" style="text-align: center; padding: 10px; height: auto;" id="password_id" class="form-control input-lg" placeholder="Your password">
+      </div>
+    </div> <!-- / Password -->
 
-  <div class="form-actions">
-    <button class="btn btn-primary" type="submit">
-      <span class="ion-android-hand"></span>
-      &nbsp;Login
-    </button>
-  </div> <!-- / .form-actions -->
+    <div class="text-center" style="margin-top: 24px;">
+      <button class="btn btn-primary" style="font-size: 16px; padding: 10px 20px;" type="submit">
+        <i class="fa fa-sign-in"></i>
+        &nbsp;Login
+      </button>
+    </div> <!-- / .form-actions -->
+
+  </div>
 </form>
 <!-- / Form -->

--- a/views/account/profile.handlebars
+++ b/views/account/profile.handlebars
@@ -8,7 +8,7 @@
   <div class="page-header">
     <div class="row">
       <!-- Page header, center on small screens -->
-      <h1 class="col-xs-12 col-sm-12 text-center text-left-sm"><i class="fa fa-user page-header-icon"></i>&nbsp;&nbsp;Account Management</h1>
+      <h1 class="text-center form-header"><i class="fa fa-user page-header-icon"></i>&nbsp;&nbsp;Account</h1>
     </div>
   </div> <!-- / .page-header -->
 
@@ -29,6 +29,11 @@
         <label class="col-sm-4 control-label" for="email">Email</label>
         <div class="col-sm-8">
           <input type="email" name="email" id="email_id" class="form-control" placeholder="E-mail" value="{{user.email}}">
+        </div>
+      </div>
+      <div class="row form-group">
+        <label class="col-sm-4 control-label" for="email">Gravatar</label>
+        <div class="col-sm-8">
           <img class="gravatar-in-form" src="{{user.gravatar}}" />
         </div>
       </div>
@@ -71,30 +76,12 @@
   </form>
   <!-- / Change Password form -->
 
-  <!-- Delete Account Form -->
-  <form action="/account/delete" class="panel form-horizontal" method="POST">
-    <input type="hidden" name="_csrf" value={{_csrf}}>
-    <div class="panel-heading">
-      <span class="panel-title">Delete Account</span>
-    </div>
-    <div class="panel-body">
-      <p>Please bear in mind that this action is irreversible.</p>
-      <button class="btn btn-danger" type="submit" onclick="return confirm('Are you sure you wish to delete your account? This is IRREVERSIBLE!');">
-        <span class="ion-trash-b"></span>
-        &nbsp;Delete My Account
-      </button>
-    </div>
-  </form>
-  <!-- / Delete Account form -->
-
-  <!-- Linked Accounts -->
+  <!--
   <div class="panel">
-    <!-- Default panel contents -->
     <div class="panel-heading">
       <span class="panel-title">Linked Accounts</span>
     </div>
 
-    <!-- List group -->
     <ul class="list-group">
       <li class="list-group-item">
         <span class="badge badge-danger"><i class="fa fa-google-plus"></i></span>
@@ -103,7 +90,7 @@
         {{else}}
         <a href="/auth/google">Link your Google account</a>
         {{/if}}
-      </li> <!-- / .list-group-item -->
+      </li>
       <li class="list-group-item">
         <span class="badge badge-info"><i class="fa fa-twitter"></i></span>
         {{#if user.twitter}}
@@ -111,7 +98,7 @@
         {{else}}
         <a href="/auth/google">Link your Twitter account</a>
         {{/if}}
-      </li> <!-- / .list-group-item -->
+      </li>
       <li class="list-group-item">
         <span class="badge btn-facebook"><i class="fa fa-facebook"></i></span>
         {{#if user.facebook}}
@@ -119,6 +106,23 @@
         {{else}}
         <a href="/auth/facebook">Link your Facebook account</a>
         {{/if}}
-      </li> <!-- / .list-group-item -->
+      </li>
     </ul>
   </div>
+  -->
+
+  <!-- Delete Account Form -->
+  <form action="/account/delete" class="panel form-horizontal" method="POST">
+    <input type="hidden" name="_csrf" value={{_csrf}}>
+    <div class="panel-heading">
+      <span class="panel-title">Delete Account</span>
+    </div>
+    <div class="panel-body" style="padding: 12px;">
+      <p>Please bear in mind that this action is irreversible.</p>
+      <button class="btn btn-danger" type="submit" onclick="return confirm('Are you sure you wish to delete your account? This is IRREVERSIBLE!');">
+        <span class="ion-trash-b"></span>
+        &nbsp;Delete My Account
+      </button>
+    </div>
+  </form>
+  <!-- / Delete Account form -->

--- a/views/account/signup.handlebars
+++ b/views/account/signup.handlebars
@@ -1,37 +1,51 @@
-<h1 class="form-header">Create your Account</h1>
+<h1 class="text-center form-header"><i class="fa fa-user page-header-icon"></i>&nbsp;&nbsp;Sign up</h1>
+
+<p style="text-align: center; padding: 12px 0 8px 0;">Already have an account? <a href="/login" class="login">Login</a></p>
 
 <!-- Form -->
-<form action="/signup" id="signup-form_id" class="panel" method="POST">
+<form action="/signup" id="signup-form_id" method="POST">
   <input type="hidden" name="_csrf" value={{_csrf}}>
 
-  <div class="form-group">
-    <input type="username" name="username" id="username_id" class="form-control input-lg" placeholder="Username" autofocus="true">
-  </div>
+  <div class="panel-body">
 
-  <div class="form-group">
-    <input type="email" name="email" id="email_id" class="form-control input-lg" placeholder="E-mail">
-  </div>
+    <div class="row form-group">
+      <div class="col-sm-12 text-center">
+        <input type="username" name="username" style="text-align: center; padding: 10px; height: auto;" id="username_id" class="form-control input-lg" placeholder="Username" autofocus="true">
+      </div>
+    </div>
 
-  <div class="form-group">
-    <input type="password" name="password" id="password_id" class="form-control input-lg" placeholder="Password">
-  </div>
+    <div class="row form-group">
+      <div class="col-sm-12 text-center">
+        <input type="email" name="email" style="text-align: center; padding: 10px; height: auto;" id="email_id" class="form-control input-lg" placeholder="E-mail">
+      </div>
+    </div>
 
-  <div class="form-group">
-    <input type="password" name="confirmPassword" id="password_confirm_id" class="form-control input-lg" placeholder="Confirm Password">
-  </div>
-<!--
-  <div class="form-group" style="margin-top: 20px;margin-bottom: 20px;">
-    <label class="checkbox-inline">
-      <input type="checkbox" name="signup_confirm" class="px" id="confirm_id">
-      <span class="lbl">I agree with the <a href="#" target="_blank">Terms and Conditions</a></span>
-    </label>
-  </div>
--->
-  <div class="form-actions">
-    <button class="btn btn-primary" type="submit">
-      <span class="ion-person-add"></span>
-      &nbsp;Create my account
-    </button>
+    <div class="row form-group">
+      <div class="col-sm-12 text-center">
+        <input type="password" name="password" style="text-align: center; padding: 10px; height: auto;" id="password_id" class="form-control input-lg" placeholder="Password">
+      </div>
+    </div>
+
+    <div class="row form-group">
+      <div class="col-sm-12 text-center">
+        <input type="password" name="confirmPassword" style="text-align: center; padding: 10px; height: auto;" id="password_confirm_id" class="form-control input-lg" placeholder="Confirm Password">
+      </div>
+    </div>
+  <!--
+    <div class="form-group" style="margin-top: 20px;margin-bottom: 20px;">
+      <label class="checkbox-inline">
+        <input type="checkbox" name="signup_confirm" class="px" id="confirm_id">
+        <span class="lbl">I agree with the <a href="#" target="_blank">Terms and Conditions</a></span>
+      </label>
+    </div>
+  -->
+    <div class="text-center" style="margin-top: 24px;">
+      <button class="btn btn-primary" style="font-size: 16px; padding: 10px 20px;" type="submit">
+        <i class="fa fa-user"></i>
+        &nbsp;Create account
+      </button>
+    </div>
+
   </div>
 </form>
 <!-- / Form -->

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -11,10 +11,10 @@
     <title>Vizor Create</title>
 
       <link href="/style/less.css" rel="Stylesheet" type="text/css"  />
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+      <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
-      <link href="/style/player.css" rel="Stylesheet" type="text/css"  />
-      <link href="/style/vizor.css" rel="Stylesheet" type="text/css"  />
+      <link href="/style/player.css" rel="Stylesheet" type="text/css" />
+      <link href="/style/website.css" rel="Stylesheet" type="text/css" />
 
     <!-- Open Sans font from Google CDN -->
     <link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&subset=latin" rel="stylesheet" type="text/css">
@@ -40,20 +40,17 @@
         {{> navbar}}
 
         <div id="content-wrapper"> <!-- formerly content-wrapper -->
-          {{#if user}}{{else}}
-            <div class="container padding-top">
-          {{/if}}
-            {{> flash}}
+            <div class="container">
+              {{> flash}}
 
-            {{{body}}}
-          {{#if user}}{{else}}
+              {{{body}}}
             </div>
-          {{/if}}
         </div>
 
     </div> <!-- / #main-wrapper -->
 
     <!-- Javascripts -->
+    {{{js 'core'}}}
     {{{js 'application'}}}
 
 </body>

--- a/views/layouts/spa.handlebars
+++ b/views/layouts/spa.handlebars
@@ -65,7 +65,7 @@
 
     <script type="text/javascript" src="/scripts/account-controller.js"></script>
     <script type="text/javascript" src="/scripts/models.js"></script>
-    
+
     <!-- // <script type="text/javascript" src="/scripts/wschannel.js"></script> -->
     <script type="text/javascript" src="/scripts/editorChannel.js"></script>
 

--- a/views/partials/navbar.handlebars
+++ b/views/partials/navbar.handlebars
@@ -1,5 +1,18 @@
 <div class="navbar navbar-default navbar-fixed-top">
   <div class="container">
-  {{> userpulldown }}
+    <ul class="nav navbar-nav navbar-left">
+      <li id="vizor-logo">
+        <div id="info">
+          <a href="/">
+            <span>
+              <img id="infopanelogo" src="../../images/logo-graphic.png">
+            </span>
+            <span>Vizor Create</span>
+          </a>
+        </div>
+      </li>
+    </ul>
+    <a id="open-the-editor" class="btn btn-lg btn-success" href="/editor">Open the Editor</a>
+    {{> userpulldown }}
   </div>
 </div>


### PR DESCRIPTION
Layout fixed, that linked accounts thing hidden, login/account/forgot password/signup headers are identical and content is centered. also from the editor, you can now open the signup modal from the login modal and vice versa without the modals overlapping. also fixed error messages for all of the POST operations on the user stuff, many of them weren’t showing up at all and some signup errors caused a break while in the editor. also changed the signup/login error messages for the editor to say sorry instead of “error happened” os. There’s some inline css in the layouts now cuz i didn’t bother taking out rules that might affect the editor too, so it needs a pass at some point.. but it all works and looks better (TM) now.