### PR TITLE
force uids and sids into strings; resolves #135

### DIFF
--- a/browser/plugins/graph.plugin.js
+++ b/browser/plugins/graph.plugin.js
@@ -319,33 +319,8 @@ GraphPlugin.prototype.state_changed = function(ui) {
 		return;
 	}
 	
-	function find_node(nodes, uid) {
-		for(var i = 0, len = nodes.length; i < len; i++) {
+	this.setupProxies()
 
-			if (nodes[i].uid !== uid)
-				continue;
-
-			var n = nodes[i]
-			var p = n.plugin
-			
-			p.data = core.get_default_value((p.id === 'input_proxy' ?
-				n.dyn_outputs
-				: n.dyn_inputs)[0]
-			.dt)
-
-			return n
-		}
-
-		msg('ERROR: Failed to find registered proxy node(' + uid + ') in graph(' + self.graph.plugin.parent_node.title + ').'); 
-		return null;
-	}
-
-	for(var uid in this.state.input_sids)
-		this.input_nodes[this.state.input_sids[uid]] = find_node(this.graph.nodes, uid);
-
-	for(var uid in this.state.output_sids)
-		this.output_nodes[this.state.output_sids[uid]] = find_node(this.graph.nodes, uid);
-		
 	var conns = node.outputs;
 	
 	for(var i = 0, len = conns.length; i < len; i++)

--- a/browser/plugins/input_proxy.plugin.js
+++ b/browser/plugins/input_proxy.plugin.js
@@ -3,17 +3,14 @@
 var InputProxy = E2.plugins.input_proxy = function(core, node) {
 	this.desc = 'Create a new type-less slot to route data into the current graph from its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.';
 	
-	this.input_slots = [];
+	this.input_slots = []
+	this.output_slots = []
 	
-	this.output_slots = [];
-	
-	this.state = {
-		slot_id: node.add_slot(E2.slot_type.output, {
-			name: 'input',
-			dt: core.datatypes.ANY,
-			desc: 'Connect this to a slot of any type, to have the parent slot assume its datatype and forward data from the parent graph.'
-		})
-	};
+	node.add_slot(E2.slot_type.output, {
+		name: 'input',
+		dt: core.datatypes.ANY,
+		desc: 'Connect this to a slot of any type, to have the parent slot assume its datatype and forward data from the parent graph.'
+	})
 
 	this.core = core;
 	this.node = node;
@@ -34,9 +31,13 @@ InputProxy.prototype.input_updated = function(data) {
 
 InputProxy.prototype.connection_changed = function(on, conn, slot) {
 	var plg = this.node.parent_graph.plugin;
-	
-	if(plg)
-		plg.proxy_connection_changed(on, this.node, conn.dst_node, slot, conn.dst_slot);
+
+	if (plg)
+		plg.proxy_connection_changed(on,
+			this.node,
+			conn.dst_node,
+			slot,
+			conn.dst_slot)
 }
 
 InputProxy.prototype.update_output = function() {

--- a/browser/plugins/loop.plugin.js
+++ b/browser/plugins/loop.plugin.js
@@ -160,29 +160,7 @@ LoopPlugin.prototype.state_changed = function(ui)
 		return;
 	}
 
-	var find_node = function(nodes, uid)
-	{
-		for(var i = 0, len = nodes.length; i < len; i++)
-		{
-			if(nodes[i].uid === uid)
-			{
-				var n = nodes[i];
-				var p = n.plugin;
-
-				p.data = core.get_default_value((p.id === 'input_proxy' ? n.dyn_outputs : n.dyn_inputs)[0].dt);
-				return n;
-			}
-		}
-
-		msg('ERROR: Failed to find registered proxy node(' + uid + ') in graph(' + self.graph.plugin.parent_node.title + ').');
-		return null;
-	};
-
-	for(var uid in this.state.input_sids)
-		this.input_nodes[this.state.input_sids[uid]] = find_node(this.graph.nodes, uid);
-
-	for(var uid in this.state.output_sids)
-		this.output_nodes[this.state.output_sids[uid]] = find_node(this.graph.nodes, uid);
+	this.setupProxies()
 
 	this.first = 0;
 	this.last = 0;

--- a/browser/plugins/output_proxy.plugin.js
+++ b/browser/plugins/output_proxy.plugin.js
@@ -6,10 +6,12 @@ E2.p = E2.plugins.output_proxy = function(core, node)
 	
 	this.output_slots = [];
 	
-	this.state = 
-	{
-		slot_id: node.add_slot(E2.slot_type.input, { name: 'output', dt: core.datatypes.ANY, desc: 'Connect a slot of any type to this plugin, to have the parent slot assume its datatype and forward data from this plugin.', def: null })
-	};
+	node.add_slot(E2.slot_type.input, {
+		name: 'output',
+		dt: core.datatypes.ANY,
+		desc: 'Connect a slot of any type to this plugin, to have the parent slot assume its datatype and forward data from this plugin.',
+		def: null
+	})
 	
 	this.core = core;
 	this.node = node;
@@ -25,13 +27,16 @@ E2.p.prototype.reset = function()
 	this.updated = true;
 };
 
-E2.p.prototype.connection_changed = function(on, conn, slot)
-{
-	var plg = this.node.parent_graph.plugin;
+E2.p.prototype.connection_changed = function(on, conn, slot) {
+	var plg = this.node.parent_graph.plugin
 	
-	if(plg)
-		plg.proxy_connection_changed(on, this.node, conn.src_node, slot, conn.src_slot);
-};
+	if (plg)
+		plg.proxy_connection_changed(on,
+			this.node,
+			conn.src_node,
+			slot,
+			conn.src_slot)
+}
 
 E2.p.prototype.update_input = function(slot, data)
 {

--- a/browser/plugins/register_local_read.plugin.js
+++ b/browser/plugins/register_local_read.plugin.js
@@ -86,7 +86,6 @@ E2.p.prototype.state_changed = function(ui) {
 
 		outputs = this.node.getDynamicOutputSlots()
 		this.slotId = outputs[0].uid
-		console.log('register read slotId', this.slotId)
 
 		this.regs = n.parent_graph.registers
 		this.target_reg(n.title)

--- a/browser/plugins/register_local_read.plugin.js
+++ b/browser/plugins/register_local_read.plugin.js
@@ -5,11 +5,6 @@ E2.p = E2.plugins["register_local_read"] = function(core, node)
 	this.input_slots = [];
 	this.output_slots = [];
 	
-	this.state = 
-	{
-		slot_id: null
-	};
-	
 	this.core = core;
 	this.node = node;
 	this.data = null;
@@ -39,7 +34,7 @@ E2.p.prototype.renamed = function()
 E2.p.prototype.register_dt_changed = function(dt)
 {
 	this.dt = dt;
-	this.node.change_slot_datatype(E2.slot_type.output, this.state.slot_id, dt);
+	this.node.change_slot_datatype(E2.slot_type.output, this.slotId, dt);
 };
 
 E2.p.prototype.register_updated = function(value)
@@ -77,19 +72,25 @@ E2.p.prototype.target_reg = function(id)
 	}
 };
 
-E2.p.prototype.state_changed = function(ui)
-{
-	if(!ui)
-	{
-		var n = this.node;
+E2.p.prototype.state_changed = function(ui) {
+	if (!ui) {
+		var n = this.node
+		var outputs = this.node.getDynamicOutputSlots()
 
-		if(this.state.slot_id === null)
-			this.state.slot_id = n.add_slot(E2.slot_type.output, { name: 'value', dt: this.core.datatypes.ANY, desc: '' });
-		
-		this.regs = n.parent_graph.registers;
-		this.target_reg(n.title);
-	}
-	else
-		this.node.ui.dom.addClass('register');
-};
+		if (!outputs.length)
+			this.node.add_slot(E2.slot_type.output, {
+				name: 'value',
+				dt: this.core.datatypes.ANY,
+				desc: ''
+			})
+
+		outputs = this.node.getDynamicOutputSlots()
+		this.slotId = outputs[0].uid
+		console.log('register read slotId', this.slotId)
+
+		this.regs = n.parent_graph.registers
+		this.target_reg(n.title)
+	} else
+		this.node.ui.dom.addClass('register')
+}
 

--- a/browser/plugins/register_local_write.plugin.js
+++ b/browser/plugins/register_local_write.plugin.js
@@ -74,7 +74,6 @@ E2.p.prototype.state_changed = function(ui) {
 
 		inputs = this.node.getDynamicInputSlots()
 		this.slotId = inputs[0].uid
-		console.log('register write slotId', this.slotId)
 
 		this.regs = n.parent_graph.registers
 		this.target_reg(n.title)

--- a/browser/plugins/register_local_write.plugin.js
+++ b/browser/plugins/register_local_write.plugin.js
@@ -5,11 +5,6 @@ E2.p = E2.plugins["register_local_write"] = function(core, node)
 	this.input_slots = [];
 	this.output_slots = [];
 	
-	this.state = 
-	{
-		slot_id: null
-	};
-	
 	this.core = core;
 	this.node = node;
 	
@@ -31,7 +26,7 @@ E2.p.prototype.destroy = function()
 
 E2.p.prototype.register_dt_changed = function(dt)
 {
-	this.node.change_slot_datatype(E2.slot_type.input, this.state.slot_id, dt);
+	this.node.change_slot_datatype(E2.slot_type.input, this.slotId, dt);
 };
 
 E2.p.prototype.renamed = function()
@@ -55,7 +50,7 @@ E2.p.prototype.update_input = function(slot, data)
 
 E2.p.prototype.target_reg = function(id)
 {
-	var dslot = this.node.find_dynamic_slot(E2.slot_type.input, this.state.slot_id);
+	var dslot = this.node.find_dynamic_slot(E2.slot_type.input, this.slotId);
 	
 	this.regs.lock(this, id);
 
@@ -65,19 +60,25 @@ E2.p.prototype.target_reg = function(id)
 		this.register_dt_changed(dslot.dt);
 };
 
-E2.p.prototype.state_changed = function(ui)
-{
-	if(!ui)
-	{
+E2.p.prototype.state_changed = function(ui) {
+	if (!ui) {
 		var n = this.node;
+		var inputs = this.node.getDynamicInputSlots()
 
-		if(this.state.slot_id === null)
-			this.state.slot_id = n.add_slot(E2.slot_type.input, { name: 'value', dt: this.core.datatypes.ANY, desc: '' });
+		if (!inputs.length)
+			this.node.add_slot(E2.slot_type.input, {
+				name: 'value',
+				dt: this.core.datatypes.ANY,
+				desc: ''
+			})
 
-		this.regs = n.parent_graph.registers;
-		this.target_reg(n.title);
-	}
-	else
-		this.node.ui.dom.addClass('register');
-};
+		inputs = this.node.getDynamicInputSlots()
+		this.slotId = inputs[0].uid
+		console.log('register write slotId', this.slotId)
+
+		this.regs = n.parent_graph.registers
+		this.target_reg(n.title)
+	} else
+		this.node.ui.dom.addClass('register')
+}
 

--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -1,5 +1,14 @@
 (function() {
 
+function getChannelFromPath(pathname) {
+	var p = pathname.split('/')
+
+	if (p.length > 2)
+		return p[1] + '/' + p[2]
+
+	return p[1]
+}
+
 function Application() {
 	var that = this;
 
@@ -43,7 +52,7 @@ function Application() {
 
 	this._mousePosition = [400,200]
 
-	this.path = window.location.pathname.split('/')[1]
+	this.path = getChannelFromPath(window.location.pathname)
 
 	this.dispatcher = new Flux.Dispatcher()
 
@@ -1501,7 +1510,9 @@ Application.prototype.openSaveACopyDialog = function(cb)
 
 Application.prototype.onPublishClicked = function() {
 	this.openSaveACopyDialog(function() {
-		window.location.href = '//vizor.io/'+window.location.pathname.split('/').slice(1,3).join('/');
+		window.location.href = '//vizor.io/' + 
+			window.location.pathname.split('/')
+				.slice(1,3).join('/');
 	})
 }
 

--- a/browser/scripts/connection.js
+++ b/browser/scripts/connection.js
@@ -143,8 +143,8 @@ Connection.prototype.serialise = function()
 };
 
 Connection.prototype.deserialise = function(d) {
-	this.src_node = d.src_nuid
-	this.dst_node = d.dst_nuid
+	this.src_node = '' + d.src_nuid
+	this.dst_node = '' + d.dst_nuid
 
 	if (this.src_node === this.dst_node)
 		debugger;

--- a/browser/scripts/core.js
+++ b/browser/scripts/core.js
@@ -288,7 +288,7 @@ Core.prototype.serialise = function()
 Core.prototype.deserialiseObject = function(d) {
 	this.abs_t = d.abs_t;
 	this.delta_t = 0.0;
-	this.graph_uid = d.graph_uid;
+	this.graph_uid = '' + d.graph_uid;
 
 	this.active_graph.destroy_ui();
 	
@@ -300,8 +300,8 @@ Core.prototype.deserialiseObject = function(d) {
 	
 	this.root_graph.patch_up(this.graphs);
 	this.root_graph.initialise(this.graphs);
-		
-	this.active_graph = resolve_graph(this.graphs, d.active_graph); 
+	
+	this.active_graph = resolve_graph(this.graphs, ''+d.active_graph); 
 	
 	if(!this.active_graph) {
 		msg('ERROR: The active graph (ID: ' + d.active_graph + ') is invalid. Using the root graph.');

--- a/browser/scripts/graph.js
+++ b/browser/scripts/graph.js
@@ -248,7 +248,7 @@ Graph.prototype.serialise = function() {
 }
 
 Graph.prototype.deserialise = function(d) {
-	this.uid = d.uid;
+	this.uid = '' + d.uid;
 	this.parent_graph = d.parent_uid;
 			
 	this.nodes = [];

--- a/browser/scripts/subGraphPlugin.js
+++ b/browser/scripts/subGraphPlugin.js
@@ -54,7 +54,7 @@ SubGraphPlugin.prototype.connection_changed = function(on, conn, slot) {
 		if (!on) {
 			if (slot.type === E2.slot_type.input) {
 				var inode = this.input_nodes[slot.uid]
-				
+
 				psl = inode.dyn_outputs[0]
 				inode.plugin.data = core.get_default_value(slot.dt)
 				inode.reset()
@@ -83,7 +83,7 @@ SubGraphPlugin.prototype.connection_changed = function(on, conn, slot) {
 					slot.dt = conn.src_slot.dt
 					this.dbg('Setting GDT for slot(' + slot.uid + ') to ' + this.get_dt_name(conn.src_slot.dt))
 				}
-				
+
 				tn = this.input_nodes[slot.uid]
 				if (!tn)
 					return;
@@ -115,7 +115,7 @@ SubGraphPlugin.prototype.proxy_connection_changed = function(on, p_node, t_node,
 	var that = this
 	var core = this.core
 	var node = this.parent_node
-	
+
 	function find_sid(nodes, uid) {
 		for (var n in nodes) {
 			if(nodes[n].uid === uid)
@@ -216,12 +216,25 @@ SubGraphPlugin.prototype.proxy_connection_changed = function(on, p_node, t_node,
 
 	if (p_node.plugin.id === 'input_proxy') {
 		last = p_node.outputs.length === 0
-		change_slots(last, node.find_dynamic_slot(E2.slot_type.input, find_sid(this.input_nodes, p_node.uid)), slot)
+		
+		change_slots(last,
+			node.find_dynamic_slot(
+				E2.slot_type.input,
+				find_sid(this.input_nodes, p_node.uid)
+			),
+		slot)
+
 		this.dbg('    Output count = ' + p_node.outputs.length)
 	} else {
 		last = p_node.inputs.length === 0
 		
-		change_slots(last, node.find_dynamic_slot(E2.slot_type.output, find_sid(this.output_nodes, p_node.uid)), slot)
+		change_slots(last,
+			node.find_dynamic_slot(
+				E2.slot_type.output,
+				find_sid(this.output_nodes, p_node.uid)
+			),
+		slot)
+
 		this.dbg('    Input count = ' + p_node.inputs.length)
 	}
 }
@@ -245,6 +258,32 @@ SubGraphPlugin.prototype.destroy_slot = function(type, nuid) {
 	delete slots[nuid]
 
 	this.parent_node.remove_slot(type, sid)
+}
+
+SubGraphPlugin.prototype.setupProxies = function() {
+	var that = this
+
+	function find_node(uid) {
+		var n = that.graph.findNodeByUid(uid)
+		if (!n)
+			return msg('ERROR: Failed to find registered proxy node(' + uid +
+				') in graph(' + self.graph.plugin.parent_node.title + ').'); 
+
+		var p = n.plugin
+		
+		p.data = E2.core.get_default_value((p.id === 'input_proxy' ?
+			n.dyn_outputs : n.dyn_inputs)[0]
+		.dt)
+
+		return n
+	}
+
+	for(var uid in this.state.input_sids) {
+		this.input_nodes[this.state.input_sids[uid]] = find_node(uid)
+	}
+
+	for(var uid in this.state.output_sids)
+		this.output_nodes[this.state.output_sids[uid]] = find_node(uid)
 }
 
 SubGraphPlugin.prototype.setGraph = function(graph) {

--- a/browser/test/unit/plugins/helpers.js
+++ b/browser/test/unit/plugins/helpers.js
@@ -88,9 +88,6 @@ exports.reset = function() {
 			on: function(){}
 		},
 		graphs: [],
-		get_graph_uid: function() {
-			return graphCounter++
-		},
 		get_default_value: function(){}
 	};
 
@@ -112,7 +109,7 @@ exports.reset = function() {
 
 	var uidCounter = 0
 	E2.core.get_uid = E2.uid = function() {
-		return parseInt(Date.now() + '' + uidCounter++, 10)
+		return Date.now() + '-' + uidCounter++
 	}
 
 	E2.dom = {


### PR DESCRIPTION
Because the uid system was changed from integers to hash strings, this needs to be done to be able to load and paste older presets and graphs. 