### PR TITLE
move Node reset and init from Node.hydrate to GraphStore._uiNodeAdded

### DIFF
--- a/browser/scripts/graphStore.js
+++ b/browser/scripts/graphStore.js
@@ -77,12 +77,12 @@ GraphStore.prototype._uiGraphTreeReordered = function(graph, original, sibling, 
 GraphStore.prototype._uiNodeAdded = function(graph, node, info) {
 	graph.addNode(node, info)
 
+	node.reset()
+	node.initialise()
+
 	mapConnections(node, function(conn) {
 		graph.connect(conn)
 	})
-
-	if (node.plugin.state_changed)
-		node.plugin.state_changed()
 
 	this.emit('nodeAdded', graph, node, info)
 

--- a/browser/scripts/node.js
+++ b/browser/scripts/node.js
@@ -578,8 +578,6 @@ Node.hydrate = function(guid, json) {
 	var node = new Node()
 	node.deserialise(guid, json)
 	node.patch_up(E2.core.graphs)
-	node.initialise()
-	node.reset()
 	return node
 }
 

--- a/browser/test/unit/graphStore.js
+++ b/browser/test/unit/graphStore.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+
+global.EventEmitter = require('events').EventEmitter
+global.Store = require('../../scripts/store')
+
+var GraphStore = require('../../scripts/graphStore')
+var Node = require('../../scripts/node')
+
+describe('GraphStore', function() {
+	var graph, node
+
+	global.E2 = {
+		uid: function() {
+			return '' + Math.random()
+		},
+		app: {
+			dispatcher: {
+				register: function(){}
+			}
+		}
+	}
+
+	beforeEach(function() {
+		graph = { addNode: function() {} }
+		node = new Node()
+		node.plugin = {}
+	})
+
+	describe('uiNodeAdded', function() {
+		it('calls reset on node', function(done) {
+			var gs = new GraphStore()
+			node.reset = done
+			gs._uiNodeAdded(graph, node)
+		})
+
+		it('calls initialise on node', function(done) {
+			var gs = new GraphStore()
+			node.initialise = done
+			gs._uiNodeAdded(graph, node)
+		})
+	})
+
+
+})

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "test:browser:unit": "mocha browser/test/unit/undo.js && mocha browser/test/unit/connection.js && mocha browser/test/unit/paste.js && mocha browser/test/unit/collapsibleSelectControl.js && mocha browser/test/unit/editConnection.js && mocha browser/test/unit/graphShapes.js && mocha browser/test/unit/node.js",
+    "test:browser:unit": "mocha browser/test/unit/undo.js && mocha browser/test/unit/connection.js && mocha browser/test/unit/paste.js && mocha browser/test/unit/collapsibleSelectControl.js && mocha browser/test/unit/editConnection.js && mocha browser/test/unit/graphShapes.js && mocha browser/test/unit/node.js && mocha browser/test/unit/graphStore.js",
     "test:browser:plugins": "mocha browser/test/unit/plugins",
     "test:browser": "npm run test:browser:unit && npm run test:browser:plugins",
     "test:server:unit": "mocha test/unit test/controllers test/services",


### PR DESCRIPTION
fixes #164

Node.reset() and Node.initialise() should really be called when the node is added to the graph, not when it is hydrated. This way, also nodes that are already hydrated (by instantiatePlugin()) will also get reset and initialised. 

Also change the order they are called, so that reset() can set the default values before initialise() calls plugin.state_changed().
