### PR TITLE
center front page vizor logo vertically

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -32,7 +32,7 @@
 				>
 			</canvas>
 
-			<hgroup class="text-center">
+			<hgroup class="frontpage-text-center">
 				<img src="images/vizor-logo-med.png">
 				
 				<h2 class="lead">

--- a/browser/style/website.css
+++ b/browser/style/website.css
@@ -40,6 +40,13 @@ h2 {
   text-align: center;
 }
 
+.frontpage-text-center {
+  text-align: center;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .lead {
   font-size: 38px;
   padding: 30px;


### PR DESCRIPTION
also fix line endings in website.css to unix...

the new css is this:
.frontpage-text-center {
  text-align: center;
  position: relative;
  top: 50%;
  transform: translateY(-50%);
}