### PR TITLE
ArraySwitch: don't render inactive inputs, resolves #332

### DIFF
--- a/browser/plugins/array_switch_modulator.plugin.js
+++ b/browser/plugins/array_switch_modulator.plugin.js
@@ -86,6 +86,10 @@ ArraySwitch.prototype.update_input = function(slot, data) {
 				this.number = n
 				this.updated = true
 			}
+
+			for (var i=0; i < this.node.dyn_inputs.length; i++)
+				this.node.dyn_inputs[i].inactive = i !== n
+
 			return 
 		}
 	} else { // dynamic slot

--- a/browser/scripts/node.js
+++ b/browser/scripts/node.js
@@ -377,7 +377,7 @@ Node.prototype._cascadeFlowOff = function(conn) {
 	if (conn.src_node.inputs.length) {
 		for (var i=0; i < conn.src_node.inputs.length; i++) {
 			if (conn.src_node.inputs[i].ui.flow)
-				cascadeFlowOff(conn.src_node.inputs[i])
+				this._cascadeFlowOff(conn.src_node.inputs[i])
 		}
 	}
 }
@@ -399,7 +399,7 @@ Node.prototype.update_recursive = function(conns) {
 		
 		if (inp.dst_slot.inactive) {
 			if(inp.ui && inp.ui.flow) {
-				cascadeFlowOff(inp)
+				this._cascadeFlowOff(inp)
 				dirty = true;
 			}
 			continue;

--- a/browser/scripts/node.js
+++ b/browser/scripts/node.js
@@ -368,66 +368,82 @@ Node.prototype.update_connections = function() {
 	return this.inputs.length + this.outputs.length
 }
 
+/**
+ * set connection UI flow state to off recursively
+ */
+function cascadeFlowOff(conn) {
+	conn.ui.flow = false
+	if (conn.src_node.inputs.length)
+		for (var i=0; i < conn.src_node.inputs.length; i++)
+			cascadeFlowOff(conn.src_node.inputs[i])
+}
+
 Node.prototype.update_recursive = function(conns) {
 	var dirty = false;
 
-	if (this.update_count < 1) {
-		var inputs = this.inputs;
-		var pl = this.plugin;
-		var needs_update = this.inputs_changed || pl.updated;
-	
-		for(var i = 0, len = inputs.length; i < len; i++) {
-			var inp = inputs[i];
-			
-			if (inp.dst_slot.inactive)
-				continue;
-			
-			var sn = inp.src_node;
-			 
-			dirty = sn.update_recursive(conns) || dirty;
-		
-			// TODO: Sampling the output value out here might seem spurious, but isn't:
-			// Some plugin require the ability to set their updated flag in update_output().
-			// Ideally, these should be rewritten to not do so, and this state should
-			// be moved into the clause below to save on function calls.
-			var value = sn.plugin.update_output(inp.src_slot);
+	if (this.update_count > 0)
+		return dirty;
 
-			if (sn.plugin.updated && (!sn.plugin.query_output || sn.plugin.query_output(inp.src_slot))) {
-				pl.update_input(inp.dst_slot, inp.dst_slot.validate ? inp.dst_slot.validate(value) : value);
-				pl.updated = true;
-				needs_update = true;
-		
-				if (inp.ui && !inp.ui.flow) {
-					dirty = true;
-					inp.ui.flow = true;
-				}
-			} else if(inp.ui && inp.ui.flow) {
-				inp.ui.flow = false;
-				dirty = true;
-			}
-		}
-	
-		if (pl.always_update || (pl.isGraph && pl.state.always_update)) {
-			pl.update_state();
-		} else if(this.queued_update > -1) {
-			if(pl.update_state)
-				pl.update_state();
-
-			pl.updated = true;
-			this.queued_update--;
-		} else if(needs_update || (pl.output_slots.length === 0 && (!this.outputs || this.outputs.length === 0))) {
-			if(pl.update_state)
-				pl.update_state();
-		
-			this.inputs_changed = false;
-		} else if(pl.input_slots.length === 0 && (!this.inputs || this.inputs.length === 0)) {
-			if(pl.update_state)
-				pl.update_state();
-		}
-	}
-	
 	this.update_count++;
 
+	var inputs = this.inputs;
+	var pl = this.plugin;
+	var needs_update = this.inputs_changed || pl.updated;
+
+	for(var i = 0, len = inputs.length; i < len; i++) {
+		var inp = inputs[i];
+		
+		if (inp.dst_slot.inactive) {
+			if(inp.ui && inp.ui.flow) {
+				cascadeFlowOff(inp)
+				dirty = true;
+			}
+			continue;
+		}
+		
+		var sn = inp.src_node;
+		 
+		dirty = sn.update_recursive(conns) || dirty;
+	
+		// TODO: Sampling the output value out here might seem spurious, but isn't:
+		// Some plugin require the ability to set their updated flag in update_output().
+		// Ideally, these should be rewritten to not do so, and this state should
+		// be moved into the clause below to save on function calls.
+		var value = sn.plugin.update_output(inp.src_slot);
+
+		if (sn.plugin.updated && (!sn.plugin.query_output || sn.plugin.query_output(inp.src_slot))) {
+			pl.update_input(inp.dst_slot, inp.dst_slot.validate ? inp.dst_slot.validate(value) : value);
+			pl.updated = true;
+			needs_update = true;
+	
+			if (inp.ui && !inp.ui.flow) {
+				dirty = true;
+				inp.ui.flow = true;
+			}
+		} else if(inp.ui && inp.ui.flow) {
+			inp.ui.flow = false;
+			dirty = true;
+		}
+	}
+
+	if (pl.always_update || (pl.isGraph && pl.state.always_update)) {
+		pl.update_state();
+	} else if(this.queued_update > -1) {
+		if(pl.update_state)
+			pl.update_state();
+
+		pl.updated = true;
+		this.queued_update--;
+	} else if(needs_update || (pl.output_slots.length === 0 && (!this.outputs || this.outputs.length === 0))) {
+		if(pl.update_state)
+			pl.update_state();
+	
+		this.inputs_changed = false;
+	} else if(pl.input_slots.length === 0 && (!this.inputs || this.inputs.length === 0)) {
+		if(pl.update_state)
+			pl.update_state();
+	}
+	
 	return dirty;
 }
 

--- a/browser/scripts/node.js
+++ b/browser/scripts/node.js
@@ -371,11 +371,15 @@ Node.prototype.update_connections = function() {
 /**
  * set connection UI flow state to off recursively
  */
-function cascadeFlowOff(conn) {
+Node.prototype._cascadeFlowOff = function(conn) {
 	conn.ui.flow = false
-	if (conn.src_node.inputs.length)
-		for (var i=0; i < conn.src_node.inputs.length; i++)
-			cascadeFlowOff(conn.src_node.inputs[i])
+
+	if (conn.src_node.inputs.length) {
+		for (var i=0; i < conn.src_node.inputs.length; i++) {
+			if (conn.src_node.inputs[i].ui.flow)
+				cascadeFlowOff(conn.src_node.inputs[i])
+		}
+	}
 }
 
 Node.prototype.update_recursive = function(conns) {


### PR DESCRIPTION
- set node dyn_input slots to inactive unless selected, resulting in skipping of rendering of those paths
- Node.js: cascade UI flow state upward
- early out in update_recursive if already rendered